### PR TITLE
Small fix to a linking bug. Removed global variable defined in header…

### DIFF
--- a/swm/src/nearest_neighbor/nearest_neighbor_swm_user_code.cpp
+++ b/swm/src/nearest_neighbor/nearest_neighbor_swm_user_code.cpp
@@ -3,6 +3,8 @@
 #include "boost_ptree_array_to_std_vector.h"
 extern uint64_t global_cycle;
 
+std::vector<msg_traffic_set*> msg_traffic_def_vector; // MM addition: normally part of base class
+
 std::string GetFirstMatch(std::string lookup_name)
 {
 
@@ -16,7 +18,7 @@ std::string GetFirstMatch(std::string lookup_name)
     return "";
     //assert(0);
 }
-                                                                            
+
 NearestNeighborSWMUserCode::NearestNeighborSWMUserCode(
     boost::property_tree::ptree cfg,
     void**& generic_ptrs
@@ -83,7 +85,7 @@ NearestNeighborSWMUserCode::xlat_coords_to_pid(
 
     pid=0;
 
-    
+
     /*std::cout << "xlat_coords_to_pid on coords ";
     for(size_t coords_idx=0; coords_idx<coords.size(); coords_idx++) {
     std::cout << " " << coords[coords_idx];
@@ -251,7 +253,7 @@ void
 NearestNeighborSWMUserCode::call()
 {
 
-    
+
     if(process_id == 0) {   //lets print every pid in coords and back again
     std::vector<uint32_t> coords;
         uint32_t pid_again;
@@ -268,7 +270,7 @@ NearestNeighborSWMUserCode::call()
 //            std::cout << pid_again << endl;
         }
     }
-    
+
 
     std::vector<uint32_t> my_coords;
     std::vector<uint32_t> neighbor_pids;
@@ -303,7 +305,7 @@ NearestNeighborSWMUserCode::call()
     uint32_t iter_before_sync = 0;
     uint32_t neighbors_size=neighbors.size();
     uint32_t pkt_rsp_bytes = 0;
-   
+
     for(uint32_t iter=0; iter<iteration_cnt; iter++)
     {
         if(process_id == 0)

--- a/swm/src/nearest_neighbor/nearest_neighbor_swm_user_code.h
+++ b/swm/src/nearest_neighbor/nearest_neighbor_swm_user_code.h
@@ -32,8 +32,6 @@
 
 #include "swm-include.h"
 
-using namespace std;
-
 typedef std::tuple<uint32_t, std::string> neighbor_tuple;
 
 typedef uint32_t RoutingType;
@@ -71,16 +69,16 @@ typedef struct msg_traffic_desc {
   uint32_t msg_req_vc;
   uint32_t msg_rsp_vc;
   uint32_t pkt_rsp_vc;
-  
+
   /*
   #ifdef FABSIM_EMULATION
   stl_l2_encoding l2_encoding;
   std::vector<uint32_t> dlid_xors;
-  
+
   uint32_t dlid_xor;
   #endif
   */
-  
+
 } msg_traffic_desc;
 
 
@@ -99,8 +97,6 @@ public:
     regex_string(regex_string)
   {}
 };
-
-std::vector<msg_traffic_set*> msg_traffic_def_vector; // MM addition: normally part of base class
 
 class NearestNeighborSWMUserCode
 {
@@ -138,7 +134,7 @@ protected:
     int process_id; //MM addition
     int req_rt; // MM addition
     int rsp_rt; // MM addition
-    
+
     uint32_t dimension_cnt;
     std::vector<uint32_t> dimension_sizes;
     uint32_t max_dimension_distance;


### PR DESCRIPTION
… file

I have no idea how this didn't present itself as a compilation bug before, but, in my machine, you should not define a variable in a header file (either .h or .hpp). If you do, the symbol will be created in as many .o it has been included. This fails to link on my computer. The linker complains with:

> /usr/bin/ld: .../build/bin/lib/libswm.a(nearest_neighbor_swm_user_code.o):.../src/nearest_neighbor/nearest_neighbor_swm_user_code.h:103: multiple definition of `msg_traffic_def_vector'; libcodes.a(codes-online-comm-wrkld.C.o):.../include/nearest_neighbor_swm_user_code.h:103: first defined here

Notice that this linking error appears only when linking statically. If we link dynamically, the error never comes up. And that's even worse! There's a dangling global (non-static) variable which can (or cannot) be accessed by other processes (?!)

Yeah, better to get rid of such thing by moving the variable definition down to where it is used, the .cpp file.